### PR TITLE
feat: 🎸 disable unique directive per location rule

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ workflows:
           version: '14'
       - publish:
           <<: *only_master
-          version: '12'
+          version: '14'
           context: common-env-vars
           requires:
             - node-10

--- a/src/__tests__/valid-federated-with-multiple-primary-keys.graphql
+++ b/src/__tests__/valid-federated-with-multiple-primary-keys.graphql
@@ -1,0 +1,16 @@
+type Sale @key(fields: "id") {
+  id: ID!
+  name: String
+  seller: User
+}
+
+extend type User @key(fields: "id") @key(fields: "netsuiteInternalId") {
+  id: ID! @external
+  netsuiteInternalId: Int
+  sales: [Sale]
+  numberOfSales: Int
+}
+
+extend type Query {
+  sales: [Sale]
+}

--- a/src/__tests__/validateSchema.test.ts
+++ b/src/__tests__/validateSchema.test.ts
@@ -13,12 +13,8 @@ function expectError(filename: string, isFederated: boolean) {
 }
 
 function expectSuccess(filename: string, isFederated: boolean) {
-  try {
-    validateSchema(filename, isFederated);
-    return expect(true);
-  } catch (ex) {
-    throw new Error('Unexpected error while validating schema');
-  }
+  validateSchema(filename, isFederated);
+  return expect(true);
 }
 
 test('non-existant.graphql', () => {

--- a/src/__tests__/validateSchema.test.ts
+++ b/src/__tests__/validateSchema.test.ts
@@ -12,6 +12,15 @@ function expectError(filename: string, isFederated: boolean) {
   throw new Error('Expected validateSchema to throw');
 }
 
+function expectSuccess(filename: string, isFederated: boolean) {
+  try {
+    validateSchema(filename, isFederated);
+    return expect(true);
+  } catch (ex) {
+    throw new Error('Unexpected error while validating schema');
+  }
+}
+
 test('non-existant.graphql', () => {
   expectError(__dirname + '/non-existant.graphql', false).toMatchInlineSnapshot(
     `"Could not find the schema at src/__tests__/non-existant.graphql"`,
@@ -91,4 +100,8 @@ test('invalid-federated-schema-2.graphql', () => {
       10 | }
     "
   `);
+});
+
+test('valid-federated-with-multiple-primary-keys.graphql', () => {
+  expectSuccess(__dirname + '/valid-federated-with-multiple-primary-keys.graphql', true).toBeTruthy();
 });


### PR DESCRIPTION
Disable unique directive per location rule to allow federation to use multiple primary keys.
With this, we now can pass rules to omit from the validation.
